### PR TITLE
Remove '% GM99 %' from getActiveCoursesFromJex query

### DIFF
--- a/services/jex/getActiveCoursesFromJex.js
+++ b/services/jex/getActiveCoursesFromJex.js
@@ -36,7 +36,6 @@ where
   and sm.crs_cde not like '% EX99 %' -- Externships
   and sm.crs_cde not like '% IS99 %' -- Independent Studies
   and sm.crs_cde not like 'OC %' -- off campus
-  and sm.crs_cde not like '% GM99 %' -- Graduate Mentored Credits
   and sm.crs_cde not like 'DT %' -- Preregistration courses
 order by year
   , term


### PR DESCRIPTION
4/13/2022
Proposed change to CANVAS-JENZABAR-INTEGRATION scripts

We are now creating courses for Graduate Mentored Credits. It would be useful for these courses to be treated just like other courses in the areas that they appear in the scripts. For example:

In the getActiveCoursesFromJex service, we might remove the highlighted portion:

where
 sm.last_end_dte >= getDate()
 and sm.crs_cde not like '% IN99 %' -- Internships
 and sm.crs_cde not like '% EX99 %' -- Externships
 and sm.crs_cde not like '% IS99 %' -- Independent Studies
 and sm.crs_cde not like 'OC %' -- off campus
 and sm.crs_cde not like '% GM99 %' -- Graduate Mentored Credits
 and sm.crs_cde not like 'DT %' -- Preregistration courses

There might be other changes necessary as well? Is this filtered anywhere else?
